### PR TITLE
add @return annotation on methods

### DIFF
--- a/src/CidrType.php
+++ b/src/CidrType.php
@@ -14,6 +14,7 @@ class CidrType extends Type
 
     /**
      * @inheritDoc
+     * @return NetworkAddress|null
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
@@ -30,6 +31,7 @@ class CidrType extends Type
 
     /**
      * @inheritDoc
+     * @return string|null
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
@@ -48,6 +50,7 @@ class CidrType extends Type
 
     /**
      * @inheritDoc
+     * @return string
      */
     public function getSQLDeclaration(array $column, AbstractPlatform $platform)
     {
@@ -56,6 +59,7 @@ class CidrType extends Type
 
     /**
      * @inheritDoc
+     * @return string
      */
     public function getName()
     {

--- a/src/InetType.php
+++ b/src/InetType.php
@@ -15,6 +15,7 @@ class InetType extends Type
 
     /**
      * @inheritDoc
+     * @return Address|NetworkAddress|null
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
@@ -35,6 +36,7 @@ class InetType extends Type
 
     /**
      * @inheritDoc
+     * @return string|null
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
@@ -53,6 +55,7 @@ class InetType extends Type
 
     /**
      * @inheritDoc
+     * @return string
      */
     public function getSQLDeclaration(array $column, AbstractPlatform $platform)
     {
@@ -61,6 +64,7 @@ class InetType extends Type
 
     /**
      * @inheritDoc
+     * @return string
      */
     public function getName()
     {


### PR DESCRIPTION
To suppress deprecation message like this:

```
User Deprecated: Method "Doctrine\DBAL\Types\Type::getName()" might add "string" as a native return type declaration in the future. Do the same in child class "SunChaser\Doctrine\PgSql\CidrType" now to avoid errors or add an explicit @return annotation to suppress this message
```